### PR TITLE
Removed Ethan from participants

### DIFF
--- a/content/tracks/Threat-Model/working-sessions/TM-api-cheatsheet.md
+++ b/content/tracks/Threat-Model/working-sessions/TM-api-cheatsheet.md
@@ -17,7 +17,6 @@ organizers   :
 participants :
  - Chris Allen
  - Adam Shostack
- - Ethan Schorer
 description  : API Threat Modeling Cheat Sheet
 locked       : true
 ---


### PR DESCRIPTION
Since it adds remote participants automatically (from my page) - there's no need to add to participants as well